### PR TITLE
Fixed nRF52840 Express Feather in examples

### DIFF
--- a/examples/bitmapdraw_featherwing/bitmapdraw_featherwing.ino
+++ b/examples/bitmapdraw_featherwing/bitmapdraw_featherwing.ino
@@ -58,7 +58,7 @@
 #endif
 
 // Anything else!
-#if defined (__AVR_ATmega32U4__) || defined(ARDUINO_SAMD_FEATHER_M0) || defined (__AVR_ATmega328P__) || defined(ARDUINO_SAMD_ZERO) || defined(__SAMD51__) || defined(__SAM3X8E__)
+#if defined (__AVR_ATmega32U4__) || defined(ARDUINO_SAMD_FEATHER_M0) || defined (__AVR_ATmega328P__) || defined(ARDUINO_SAMD_ZERO) || defined(__SAMD51__) || defined(__SAM3X8E__) || defined(ARDUINO_NRF52_FEATHER)
    #define STMPE_CS 6
    #define TFT_CS   9
    #define TFT_DC   10

--- a/examples/gfxbuttontest_featherwing/gfxbuttontest_featherwing.ino
+++ b/examples/gfxbuttontest_featherwing/gfxbuttontest_featherwing.ino
@@ -46,7 +46,7 @@
    #define SD_CS    P3_2
 
 // Something else!
-#elif  defined (__AVR_ATmega32U4__) || defined(ARDUINO_SAMD_FEATHER_M0) || defined (__AVR_ATmega328P__) || defined(ARDUINO_SAMD_ZERO) || defined(__SAMD51__)   
+#elif  defined (__AVR_ATmega32U4__) || defined(ARDUINO_SAMD_FEATHER_M0) || defined (__AVR_ATmega328P__) || defined(ARDUINO_SAMD_ZERO) || defined(__SAMD51__) || defined(__SAM3X8E__) || defined(ARDUINO_NRF52_FEATHER)  
    #define STMPE_CS 6
    #define TFT_CS   9
    #define TFT_DC   10

--- a/examples/graphicstest_featherwing/graphicstest_featherwing.ino
+++ b/examples/graphicstest_featherwing/graphicstest_featherwing.ino
@@ -55,7 +55,7 @@
 #endif
 
 // Anything else!
-#if defined (__AVR_ATmega32U4__) || defined(ARDUINO_SAMD_FEATHER_M0) || defined (__AVR_ATmega328P__) || defined(ARDUINO_SAMD_ZERO) || defined(__SAMD51__) || defined(__SAM3X8E__)
+#if defined (__AVR_ATmega32U4__) || defined(ARDUINO_SAMD_FEATHER_M0) || defined (__AVR_ATmega328P__) || defined(ARDUINO_SAMD_ZERO) || defined(__SAMD51__) || defined(__SAM3X8E__) || defined(ARDUINO_NRF52_FEATHER)
    #define STMPE_CS 6
    #define TFT_CS   9
    #define TFT_DC   10

--- a/examples/touchpaint_featherwing/touchpaint_featherwing.ino
+++ b/examples/touchpaint_featherwing/touchpaint_featherwing.ino
@@ -56,7 +56,7 @@
 #endif
 
 // Anything else!
-#if defined (__AVR_ATmega32U4__) || defined(ARDUINO_SAMD_FEATHER_M0) || defined (__AVR_ATmega328P__) || defined(ARDUINO_SAMD_ZERO) || defined(__SAMD51__) || defined(__SAM3X8E__)
+#if defined (__AVR_ATmega32U4__) || defined(ARDUINO_SAMD_FEATHER_M0) || defined (__AVR_ATmega328P__) || defined(ARDUINO_SAMD_ZERO) || defined(__SAMD51__) || defined(__SAM3X8E__) || defined(ARDUINO_NRF52_FEATHER)
    #define STMPE_CS 6
    #define TFT_CS   9
    #define TFT_DC   10


### PR DESCRIPTION
I added a check for the nRF52840 based on the define in the Adafruit nRF52 0.10.1 by Adafruit boards package.