### PR TITLE
Moved readcommand8() to GFX

### DIFF
--- a/Adafruit_HX8357.cpp
+++ b/Adafruit_HX8357.cpp
@@ -357,27 +357,3 @@ void Adafruit_HX8357::setAddrWindow(
   SPI_WRITE16(y2);
   writeCommand(HX8357_RAMWR); // Write to RAM
 }
-
-/*!
-    @brief   Read 8 bits of data from HX8357 configuration memory (not RAM).
-             This is highly undocumented/supported and should be avoided,
-             function is only included because some of the examples use it.
-    @param   command
-             The command register to read data from.
-    @param   index
-             The byte index into the command to read from.
-    @return  Unsigned 8-bit data read from HX8357 register.
-*/
-/**************************************************************************/
-uint8_t Adafruit_HX8357::readcommand8(uint8_t command, uint8_t index) {
-   uint8_t result;
-   startWrite();
-   SPI_DC_LOW();
-   spiWrite(command);
-   SPI_DC_HIGH();
-   do {
-     result = spiRead();
-   } while(index--); // Discard bytes up to index'th
-   endWrite();
-   return result;
-}

--- a/Adafruit_HX8357.h
+++ b/Adafruit_HX8357.h
@@ -138,7 +138,6 @@ class Adafruit_HX8357 : public Adafruit_SPITFT {
             setRotation(uint8_t r),
             invertDisplay(boolean i),
             setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
-    uint8_t readcommand8(uint8_t command, uint8_t index = 0);
   private:
     uint8_t displayType; // HX8357D vs HX8357B
 };

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit HX8357 Library
-version=1.1.4
+version=1.1.5
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Adafruit HX8357 3.5" display library.


### PR DESCRIPTION
Travis will most likely fail for the moment until the latest GFX library has had time to propagate.