### PR TITLE
Fix frequency not changing when calling Adafruit_HX8357::begin

### DIFF
--- a/Adafruit_HX8357.cpp
+++ b/Adafruit_HX8357.cpp
@@ -255,7 +255,7 @@ void Adafruit_HX8357::begin(uint32_t freq) {
   if(freq == HX8357D) {
     displayType = freq;
     freq        = 0; // Use default SPI frequency
-  } else if(HX8357B) {
+  } else if(freq == HX8357B) {
     displayType = freq;
     freq        = 0; // Use default SPI frequency
   }


### PR DESCRIPTION
Fix frequency not changing when calling Adafruit_HX8357::begin(uint32_t freq = 0)

Scope: Fix ```else if``` statement on line 258 in Adafruit_HX8357::begin from:
```} else if(HX8357B) {```
to:
```} else if(freq == HX8357B) {```
This change ensures that a request to change the SPI bus frequency will be taken into account.

Known limitations: none

Tests: running and passing
