### PR TITLE
Fix incorrect value of TFT_CS for nrf52832

### DIFF
--- a/examples/gfxbuttontest_featherwing/gfxbuttontest_featherwing.ino
+++ b/examples/gfxbuttontest_featherwing/gfxbuttontest_featherwing.ino
@@ -35,7 +35,7 @@
   
 #elif defined ARDUINO_NRF52832_FEATHER
    #define STMPE_CS 30
-   #define TFT_CS   13
+   #define TFT_CS   31
    #define TFT_DC   11
    #define SD_CS    27
 

--- a/examples/graphicstest_featherwing/graphicstest_featherwing.ino
+++ b/examples/graphicstest_featherwing/graphicstest_featherwing.ino
@@ -43,7 +43,7 @@
 #endif
 #ifdef ARDUINO_NRF52832_FEATHER
    #define STMPE_CS 30
-   #define TFT_CS   13
+   #define TFT_CS   31
    #define TFT_DC   11
    #define SD_CS    27
 #endif

--- a/examples/touchpaint_featherwing/touchpaint_featherwing.ino
+++ b/examples/touchpaint_featherwing/touchpaint_featherwing.ino
@@ -44,7 +44,7 @@
 #endif
 #ifdef ARDUINO_NRF52832_FEATHER
    #define STMPE_CS 30
-   #define TFT_CS   13
+   #define TFT_CS   31
    #define TFT_DC   11
    #define SD_CS    27
 #endif


### PR DESCRIPTION
This is a small change but as stated in https://learn.adafruit.com/adafruit-3-5-tft-featherwing/pinouts, the value of TFT_CS should be 31. Tested with nrf52832 and 3.5" TFT featherwing.

https://github.com/adafruit/Adafruit_HX8357_Library/issues/33