### PR TITLE
added support for unphones (see https://unphone.net/ for details)

### DIFF
--- a/Adafruit_HX8357.cpp
+++ b/Adafruit_HX8357.cpp
@@ -222,7 +222,11 @@ static const uint8_t PROGMEM
             0x00,
             HX8357_MADCTL,
             1,
+#ifdef UNPHONE_SPIN
+            0x88, // by default the unphone screen reverses orientation / colour
+#else
             0xC0,
+#endif
             HX8357_COLMOD,
             1,
             0x55,
@@ -338,7 +342,11 @@ static const uint8_t PROGMEM
         0x55, // 16 bit
         HX8357_MADCTL,
         1,
+#ifdef UNPHONE_SPIN
+        0x88, // by default the unphone screen reverses orientation / colour
+#else
         0xC0,
+#endif
         HX8357_TEON,
         1,
         0x00, // TW off


### PR DESCRIPTION
This is a non-breaking change (two "#ifdef"s) that adds support for the unphone device (which, otherwise, reverses the direction and colours of the screen). The unphone is described at https://unphone.net/ and is a collaboration between Pimoroni and the University of Sheffield -- see https://iot.unphone/net/ -- where we use it for teaching (along with a couple of hundred ESP32 Feathers per year), and have designed it with an expander board that uses the Featherwing standard. It will release in retail version Q1 2023. While it isn't an Adafruit product, it would be nice if support could be part of the mainstream library. No worries if not!
