### PR TITLE
Feather ESP32-S3 support in FeatherWing examples

### DIFF
--- a/examples/bitmapdraw_featherwing/bitmapdraw_featherwing.ino
+++ b/examples/bitmapdraw_featherwing/bitmapdraw_featherwing.ino
@@ -25,7 +25,7 @@
    #define TFT_CS   0
    #define TFT_DC   15
    #define SD_CS    2
-#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
+#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S3)
    #define STMPE_CS 32
    #define TFT_CS   15
    #define TFT_DC   33

--- a/examples/gfxbuttontest_featherwing/gfxbuttontest_featherwing.ino
+++ b/examples/gfxbuttontest_featherwing/gfxbuttontest_featherwing.ino
@@ -13,7 +13,7 @@
    #define TFT_CS   0
    #define TFT_DC   15
    #define SD_CS    2
-#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
+#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S3)
    #define STMPE_CS 32
    #define TFT_CS   15
    #define TFT_DC   33

--- a/examples/graphicstest_featherwing/graphicstest_featherwing.ino
+++ b/examples/graphicstest_featherwing/graphicstest_featherwing.ino
@@ -22,7 +22,7 @@
    #define TFT_CS   0
    #define TFT_DC   15
    #define SD_CS    2
-#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
+#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S3)
    #define STMPE_CS 32
    #define TFT_CS   15
    #define TFT_DC   33

--- a/examples/touchpaint_featherwing/touchpaint_featherwing.ino
+++ b/examples/touchpaint_featherwing/touchpaint_featherwing.ino
@@ -23,7 +23,7 @@
    #define TFT_CS   0
    #define TFT_DC   15
    #define SD_CS    2
-#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
+#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S3)
    #define STMPE_CS 32
    #define TFT_CS   15
    #define TFT_DC   33


### PR DESCRIPTION
This is a simple change to add support to the examples for the new Feather ESP32-S3 boards, they follow the standard pinouts so they don't need any special pin definitions. Nothing fancy, this just adds another exclusion to the more generic ESP32 pin definitions so that the standard pin definitions apply to the S3 Feathers.
