### PR TITLE
Added support for the scrolling feature found in the ILI9341 library. 

### DIFF
--- a/Adafruit_HX8357.cpp
+++ b/Adafruit_HX8357.cpp
@@ -477,3 +477,35 @@ void Adafruit_HX8357::setAddrWindow(uint16_t x1, uint16_t y1, uint16_t w,
   SPI_WRITE16(y2);
   writeCommand(HX8357_RAMWR); // Write to RAM
 }
+
+/*!
+    @brief   Scroll display memory
+    @param   y How many pixels to scroll display by
+*/
+void Adafruit_HX8357::scrollTo(uint16_t y) {
+  uint8_t data[2];
+  data[0] = y >> 8;
+  data[1] = y & 0xff;
+  sendCommand(HX8357_VSCRSADD, (uint8_t *)data, 2);
+}
+
+
+/*!
+    @brief   Set the height of the Top and Bottom Scroll Margins
+    @param   top The height of the Top scroll margin
+    @param   bottom The height of the Bottom scroll margin
+ */
+void Adafruit_HX8357::setScrollMargins(uint16_t top, uint16_t bottom) {
+  // TFA+VSA+BFA must equal 320
+  if (top + bottom <= HX8357_TFTHEIGHT) {
+    uint16_t middle = HX8357_TFTHEIGHT - (top + bottom);
+    uint8_t data[6];
+    data[0] = top >> 8;
+    data[1] = top & 0xff;
+    data[2] = middle >> 8;
+    data[3] = middle & 0xff;
+    data[4] = bottom >> 8;
+    data[5] = bottom & 0xff;
+    sendCommand(HX8357_VSCRDEF, (uint8_t *)data, 6);
+  }
+}

--- a/Adafruit_HX8357.cpp
+++ b/Adafruit_HX8357.cpp
@@ -489,7 +489,6 @@ void Adafruit_HX8357::scrollTo(uint16_t y) {
   sendCommand(HX8357_VSCRSADD, (uint8_t *)data, 2);
 }
 
-
 /*!
     @brief   Set the height of the Top and Bottom Scroll Margins
     @param   top The height of the Top scroll margin

--- a/Adafruit_HX8357.h
+++ b/Adafruit_HX8357.h
@@ -65,11 +65,13 @@
 #define HX8357_RAMWR 0x2C ///< Write VRAM
 #define HX8357_RAMRD 0x2E ///< Read VRAm
 
-#define HX8357B_PTLAR 0x30   ///< (unknown)
-#define HX8357_TEON 0x35     ///< Tear enable on
-#define HX8357_TEARLINE 0x44 ///< (unknown)
-#define HX8357_MADCTL 0x36   ///< Memory access control
-#define HX8357_COLMOD 0x3A   ///< Color mode
+#define HX8357B_PTLAR 0x30    ///< (unknown)
+#define HX8357_VSCRDEF 0x33  ///< Vertical Scrolling Definition
+#define HX8357_TEON 0x35      ///< Tear enable on
+#define HX8357_TEARLINE 0x44  ///< (unknown)
+#define HX8357_MADCTL 0x36    ///< Memory access control
+#define HX8357_VSCRSADD 0x37 ///< Vertical Scrolling Start Address
+#define HX8357_COLMOD 0x3A    ///< Color mode
 
 #define HX8357_SETOSC 0xB0      ///< Set oscillator
 #define HX8357_SETPWR1 0xB1     ///< Set power control
@@ -139,6 +141,9 @@ public:
   void begin(uint32_t freq = 0), setRotation(uint8_t r),
       invertDisplay(boolean i),
       setAddrWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
+
+  void scrollTo(uint16_t y);
+  void setScrollMargins(uint16_t top, uint16_t bottom);
 
 private:
   uint8_t displayType; // HX8357D vs HX8357B

--- a/Adafruit_HX8357.h
+++ b/Adafruit_HX8357.h
@@ -66,11 +66,11 @@
 #define HX8357_RAMRD 0x2E ///< Read VRAm
 
 #define HX8357B_PTLAR 0x30    ///< (unknown)
-#define HX8357_VSCRDEF 0x33  ///< Vertical Scrolling Definition
+#define HX8357_VSCRDEF 0x33   ///< Vertical Scrolling Definition
 #define HX8357_TEON 0x35      ///< Tear enable on
 #define HX8357_TEARLINE 0x44  ///< (unknown)
 #define HX8357_MADCTL 0x36    ///< Memory access control
-#define HX8357_VSCRSADD 0x37 ///< Vertical Scrolling Start Address
+#define HX8357_VSCRSADD 0x37  ///< Vertical Scrolling Start Address
 #define HX8357_COLMOD 0x3A    ///< Color mode
 
 #define HX8357_SETOSC 0xB0      ///< Set oscillator

--- a/Adafruit_HX8357.h
+++ b/Adafruit_HX8357.h
@@ -65,13 +65,13 @@
 #define HX8357_RAMWR 0x2C ///< Write VRAM
 #define HX8357_RAMRD 0x2E ///< Read VRAm
 
-#define HX8357B_PTLAR 0x30    ///< (unknown)
-#define HX8357_VSCRDEF 0x33   ///< Vertical Scrolling Definition
-#define HX8357_TEON 0x35      ///< Tear enable on
-#define HX8357_TEARLINE 0x44  ///< (unknown)
-#define HX8357_MADCTL 0x36    ///< Memory access control
-#define HX8357_VSCRSADD 0x37  ///< Vertical Scrolling Start Address
-#define HX8357_COLMOD 0x3A    ///< Color mode
+#define HX8357B_PTLAR 0x30   ///< (unknown)
+#define HX8357_VSCRDEF 0x33  ///< Vertical Scrolling Definition
+#define HX8357_TEON 0x35     ///< Tear enable on
+#define HX8357_TEARLINE 0x44 ///< (unknown)
+#define HX8357_MADCTL 0x36   ///< Memory access control
+#define HX8357_VSCRSADD 0x37 ///< Vertical Scrolling Start Address
+#define HX8357_COLMOD 0x3A   ///< Color mode
 
 #define HX8357_SETOSC 0xB0      ///< Set oscillator
 #define HX8357_SETPWR1 0xB1     ///< Set power control


### PR DESCRIPTION
Added support for the scrolling feature found in the ILI9341 library. The registers and code from the source library are just a drop in based on the HX8357 datasheet. This change has been tested on the 3.5" Featherwing TFT and works as expected.

